### PR TITLE
Playgame logic

### DIFF
--- a/src/components/CreateGame/CreateGame.js
+++ b/src/components/CreateGame/CreateGame.js
@@ -52,7 +52,7 @@ export class CreateGame extends React.Component {
 					skipPenalty,
 					players: [],
 					gameplay: {
-						round: 0,
+						round: 1,
 						status: "preround",
 						half: "top",	
 						team1Turn: 0,

--- a/src/components/CreateGame/CreateGame.js
+++ b/src/components/CreateGame/CreateGame.js
@@ -51,6 +51,15 @@ export class CreateGame extends React.Component {
 					endValue,
 					skipPenalty,
 					players: [],
+					gameplay: {
+						round: 0,
+						status: "preround",
+						half: "top",	
+						team1Turn: 0,
+						team2Turn: 0,
+						team1Rotations: 0,
+						team2Rotations: 0
+					}
 				}
 				console.log("setstate done")
 

--- a/src/components/GameCard/GameCard.js
+++ b/src/components/GameCard/GameCard.js
@@ -4,18 +4,21 @@ import { ButtonTabooCard, TabooCard } from 'components/shared/TabooCard'
 import { InstructionsText, KeyWord } from './style'
 
 //current card object, skip and next callback.
-export const GiverGameCard = () => {
+export const GiverGameCard = ({ changeCardStatus }) => {
 	const buttonInfo = [
 		{
 			text: 'Skip!',
 			onClick: () => {
 				console.log('skip card')
+				console.log("next")
+				changeCardStatus('Skip card')
 			},
 		},
 		{
 			text: 'Next!',
 			onClick: () => {
-				console.log('Next card')
+				console.log("next")
+				changeCardStatus('Next card')
 			},
 		},
 	]
@@ -59,8 +62,8 @@ export const TeamGameCard = ({ role, giver, watcher }) => {
 			) : (
 				<TabooCard tabooWord="Relax!">
 					<InstructionsText>
-						It’s the other team’s turn to give clues and guess!	<KeyWord>{watcher.name}</KeyWord> will be watching to make sure <KeyWord>{giver.name}</KeyWord>{' '}
-						doesn’t say any Taboo words.
+						It’s the other team’s turn to give clues and guess! <KeyWord>{watcher.name}</KeyWord> will be
+						watching to make sure <KeyWord>{giver.name}</KeyWord> doesn’t say any Taboo words.
 					</InstructionsText>
 				</TabooCard>
 			)}

--- a/src/components/GameCard/GameCard.js
+++ b/src/components/GameCard/GameCard.js
@@ -4,31 +4,29 @@ import { ButtonTabooCard, TabooCard } from 'components/shared/TabooCard'
 import { InstructionsText, KeyWord } from './style'
 
 //current card object, skip and next callback.
-export const GiverGameCard = ({ changeCardStatus }) => {
+export const GiverGameCard = ({ currentCard, changeCardStatus, isPending }) => {
 	const buttonInfo = [
 		{
 			text: 'Skip!',
+			disabled: isPending,
 			onClick: () => {
 				console.log('skip card')
-				console.log("next")
-				changeCardStatus('Skip card')
+				changeCardStatus('skipped')
 			},
 		},
 		{
 			text: 'Next!',
+			disabled: isPending,
+
 			onClick: () => {
 				console.log("next")
-				changeCardStatus('Next card')
+				changeCardStatus('correct')
 			},
 		},
 	]
 
-	const card = {
-		tabooWord: 'Simba',
-		words: ['Lion King', 'Disney', 'Mufasa', 'Pride Rock', 'Nala'],
-	}
 
-	return <ButtonTabooCard buttons={buttonInfo} tabooWord={card.tabooWord} list={card.words} />
+	return <ButtonTabooCard buttons={buttonInfo} tabooWord={currentCard.word} list={currentCard.tabooList} />
 }
 
 export const WatcherGameCard = () => {

--- a/src/components/GameCard/GameCard.js
+++ b/src/components/GameCard/GameCard.js
@@ -17,7 +17,6 @@ export const GiverGameCard = ({ currentCard, changeCardStatus, isPending }) => {
 		{
 			text: 'Next!',
 			disabled: isPending,
-
 			onClick: () => {
 				console.log("next")
 				changeCardStatus('correct')
@@ -29,22 +28,19 @@ export const GiverGameCard = ({ currentCard, changeCardStatus, isPending }) => {
 	return <ButtonTabooCard buttons={buttonInfo} tabooWord={currentCard.word} list={currentCard.tabooList} />
 }
 
-export const WatcherGameCard = () => {
+export const WatcherGameCard = ({currentCard, changeCardStatus, isPending}) => {
 	const buttonInfo = [
 		{
 			text: 'Buzzer!',
+			disabled: isPending,
 			onClick: () => {
-				console.log('Buzz')
-			},
+				console.log("discard")
+				changeCardStatus('discard')
+			}
 		},
 	]
 
-	const card = {
-		tabooWord: 'Simba',
-		words: ['Lion King', 'Disney', 'Mufasa', 'Pride Rock', 'Nala'],
-	}
-
-	return <ButtonTabooCard buttons={buttonInfo} tabooWord={card.tabooWord} list={card.words} />
+	return <ButtonTabooCard buttons={buttonInfo} tabooWord={currentCard.word} list={currentCard.tabooList} />
 }
 
 export const TeamGameCard = ({ role, giver, watcher }) => {

--- a/src/components/GameCard/GameCard.js
+++ b/src/components/GameCard/GameCard.js
@@ -3,7 +3,6 @@ import PropType from 'prop-types'
 import { ButtonTabooCard, TabooCard } from 'components/shared/TabooCard'
 import { InstructionsText, KeyWord } from './style'
 
-//current card object, skip and next callback.
 export const GiverGameCard = ({ currentCard, changeCardStatus, isPending }) => {
 	const buttonInfo = [
 		{
@@ -28,6 +27,12 @@ export const GiverGameCard = ({ currentCard, changeCardStatus, isPending }) => {
 	return <ButtonTabooCard buttons={buttonInfo} tabooWord={currentCard.word} list={currentCard.tabooList} />
 }
 
+GiverGameCard.propType = {
+	currentCard: PropType.object.isRequired,
+	changeCardStatus: PropType.func.isRequired,
+	isPending: PropType.bool.isRequired
+}
+
 export const WatcherGameCard = ({currentCard, changeCardStatus, isPending}) => {
 	const buttonInfo = [
 		{
@@ -41,6 +46,12 @@ export const WatcherGameCard = ({currentCard, changeCardStatus, isPending}) => {
 	]
 
 	return <ButtonTabooCard buttons={buttonInfo} tabooWord={currentCard.word} list={currentCard.tabooList} />
+}
+
+WatcherGameCard.propType = {
+	currentCard: PropType.object.isRequired,
+	changeCardStatus: PropType.func.isRequired,
+	isPending: PropType.bool.isRequired
 }
 
 export const TeamGameCard = ({ role, giver, watcher }) => {

--- a/src/components/GameCard/__tests__/GameCard.test.js
+++ b/src/components/GameCard/__tests__/GameCard.test.js
@@ -1,74 +1,140 @@
 import React from 'react'
 import renderer from 'react-test-renderer'
-import { mount } from 'enzyme'
+import { shallow, mount } from 'enzyme'
 import { ThemeProvider } from 'styled-components'
 import theme from '../../../global-design/theme'
 import { GiverGameCard, WatcherGameCard, TeamGameCard } from '../index'
 
-test('GiverGameCard renders correctly', () => {
-	const wrapper = renderer
-		.create(
-			<ThemeProvider theme={theme}>
-				<GiverGameCard />
-			</ThemeProvider>
-		)
-		.toJSON()
-
-	expect(wrapper).toMatchSnapshot()
-})
-
-test('WatcherGameCard renders correctly', () => {
-	const wrapper = renderer
-		.create(
-			<ThemeProvider theme={theme}>
-				<WatcherGameCard />
-			</ThemeProvider>
-		)
-		.toJSON()
-
-	expect(wrapper).toMatchSnapshot()
-})
-
-test('TeamGameCard renders correctly', () => {
-	const props = {
-		role: 'watcherTeam',
-		giver: {
-            name: 'Joe'
-        },
-		watcher: {
-            name: 'Sam'
-        },
+describe('GameCard functionality and rendering', () => {
+	const defaultProps = {
+		currentCard: {
+			word: 'Will Smith',
+			tabooList: ['Fresh Prince', 'Philadelphia', 'Jazzy Jeff', 'Independence Day', 'Jada Pinkett'],
+		},
+		changeCardStatus: jest.fn(),
+		isPending: false,
 	}
-	const wrapper = renderer
-		.create(
+
+	test('GiverGameCard renders correctly', () => {
+		const props = {
+			...defaultProps,
+		}
+		const wrapper = renderer
+			.create(
+				<ThemeProvider theme={theme}>
+					<GiverGameCard {...props} />
+				</ThemeProvider>
+			)
+			.toJSON()
+
+		expect(wrapper).toMatchSnapshot()
+	})
+
+	test("Selecting 'Skip' calls props.changeCardStatus with correct status", () => {
+		const props = {
+			...defaultProps,
+		}
+
+		const wrapper = mount(
 			<ThemeProvider theme={theme}>
-				<TeamGameCard {...props} />
+				<GiverGameCard {...props} />
+			</ThemeProvider>
+		)	
+
+		 wrapper.find("button").at(0).simulate("click")
+		 expect(props.changeCardStatus).toHaveBeenCalledWith("skipped")    
+		
+	})
+
+	test("Selecting 'Next' calls props.changeCardStatus with correct status", () => {
+		const props = {
+			...defaultProps,
+		}
+
+		const wrapper = mount(
+			<ThemeProvider theme={theme}>
+				<GiverGameCard {...props} />
 			</ThemeProvider>
 		)
-		.toJSON()
 
-	expect(wrapper).toMatchSnapshot()
-})
+		 wrapper.find("button").at(1).simulate("click")
+		 expect(props.changeCardStatus).toHaveBeenCalledWith("correct")    
+		
+	})
 
-test('TeamGameCard renders correct instructions based on role prop', () => {
-	const props = {
-		role: 'watcherTeam',
-		giver: {
-            name: 'Joe'
-        },
-		watcher: {
-            name: 'Sam'
-        },
-	}
-	const wrapper = mount(
-		<ThemeProvider theme={theme}>
-			<TeamGameCard {...props} />
-		</ThemeProvider>
-	)
+	test('WatcherGameCard renders correctly', () => {
+		const props = {
+			...defaultProps,
+		}
+		const wrapper = renderer
+			.create(
+				<ThemeProvider theme={theme}>
+					<WatcherGameCard {...props} />
+				</ThemeProvider>
+			)
+			.toJSON()
 
-	const div = wrapper.find('div').at(0)
+		expect(wrapper).toMatchSnapshot()
+	})
 
-	expect(div.text()).toEqual(
-		`Relax!It’s the other team’s turn to give clues and guess! ${props.watcher.name} will be watching to make sure ${props.giver.name} doesn’t say any Taboo words.`
-	)
+	test("Selecting 'Buzzer' calls props.changeCardStatus with correct status", () => {
+		const props = {
+			...defaultProps,
+		}
+
+		const wrapper = mount(
+			<ThemeProvider theme={theme}>
+				<WatcherGameCard {...props} />
+			</ThemeProvider>
+		)
+
+		 wrapper.find("button").at(0).simulate("click")
+		 expect(props.changeCardStatus).toHaveBeenCalledWith("discard")    
+		
+	})
+
+
+
+	test('TeamGameCard renders correctly for watcherTeam', () => {
+		const props = {
+			role: 'watcherTeam',
+			giver: {
+				name: 'Joe',
+			},
+			watcher: {
+				name: 'Sam',
+			},
+		}
+		const wrapper = renderer
+			.create(
+				<ThemeProvider theme={theme}>
+					<TeamGameCard {...props} />
+				</ThemeProvider>
+			)
+			.toJSON()
+
+		expect(wrapper).toMatchSnapshot()
+	})
+
+	
+	test('TeamGameCard renders correctly for giverTeam', () => {
+		const props = {
+			role: 'giverTeam',
+			giver: {
+				name: 'Joe',
+			},
+			watcher: {
+				name: 'Sam',
+			},
+		}
+		const wrapper = renderer
+			.create(
+				<ThemeProvider theme={theme}>
+					<TeamGameCard {...props} />
+				</ThemeProvider>
+			)
+			.toJSON()
+
+		expect(wrapper).toMatchSnapshot()
+	})
 })

--- a/src/components/GameCard/__tests__/__snapshots__/GameCard.test.js.snap
+++ b/src/components/GameCard/__tests__/__snapshots__/GameCard.test.js.snap
@@ -1,13 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`GiverGameCard renders correctly 1`] = `
+exports[`GameCard functionality and rendering GiverGameCard renders correctly 1`] = `
 <div
   className="sc-AxjAm fAwBWA"
 >
   <div
     className="sc-AxiKw dGnLMo"
   >
-    Simba
+    Will Smith
   </div>
   <div
     className="sc-AxhCb JZaCe"
@@ -18,27 +18,27 @@ exports[`GiverGameCard renders correctly 1`] = `
       <li
         className="sc-AxgMl cDzLXU"
       >
-        Lion King
+        Fresh Prince
       </li>
       <li
         className="sc-AxgMl cDzLXU"
       >
-        Disney
+        Philadelphia
       </li>
       <li
         className="sc-AxgMl cDzLXU"
       >
-        Mufasa
+        Jazzy Jeff
       </li>
       <li
         className="sc-AxgMl cDzLXU"
       >
-        Pride Rock
+        Independence Day
       </li>
       <li
         className="sc-AxgMl cDzLXU"
       >
-        Nala
+        Jada Pinkett
       </li>
     </ul>
   </div>
@@ -47,12 +47,14 @@ exports[`GiverGameCard renders correctly 1`] = `
   >
     <button
       className="sc-AxheI bYfwqV"
+      disabled={false}
       onClick={[Function]}
     >
       Skip!
     </button>
     <button
       className="sc-AxheI sc-Axmtr jEDxKF"
+      disabled={false}
       onClick={[Function]}
     >
       Next!
@@ -61,7 +63,41 @@ exports[`GiverGameCard renders correctly 1`] = `
 </div>
 `;
 
-exports[`TeamGameCard renders correctly 1`] = `
+exports[`GameCard functionality and rendering TeamGameCard renders correctly for giverTeam 1`] = `
+<div
+  className="sc-AxjAm fAwBWA"
+>
+  <div
+    className="sc-AxiKw dGnLMo"
+  >
+    Guess!
+  </div>
+  <div
+    className="sc-AxhCb JZaCe"
+  >
+    <p
+      className="sc-fzpans ifLBye"
+    >
+      It's your teams turn to guess the word! 
+      <span
+        className="sc-fzplWN kxXpQP"
+      >
+        Joe
+      </span>
+       is giving the clues and
+       
+      <span
+        className="sc-fzplWN kxXpQP"
+      >
+        Sam
+      </span>
+       will be making sure they don't say anything Taboo!
+    </p>
+  </div>
+</div>
+`;
+
+exports[`GameCard functionality and rendering TeamGameCard renders correctly for watcherTeam 1`] = `
 <div
   className="sc-AxjAm fAwBWA"
 >
@@ -88,21 +124,20 @@ exports[`TeamGameCard renders correctly 1`] = `
       >
         Joe
       </span>
-       
-      doesn’t say any Taboo words.
+       doesn’t say any Taboo words.
     </p>
   </div>
 </div>
 `;
 
-exports[`WatcherGameCard renders correctly 1`] = `
+exports[`GameCard functionality and rendering WatcherGameCard renders correctly 1`] = `
 <div
   className="sc-AxjAm fAwBWA"
 >
   <div
     className="sc-AxiKw dGnLMo"
   >
-    Simba
+    Will Smith
   </div>
   <div
     className="sc-AxhCb JZaCe"
@@ -113,27 +148,27 @@ exports[`WatcherGameCard renders correctly 1`] = `
       <li
         className="sc-AxgMl cDzLXU"
       >
-        Lion King
+        Fresh Prince
       </li>
       <li
         className="sc-AxgMl cDzLXU"
       >
-        Disney
+        Philadelphia
       </li>
       <li
         className="sc-AxgMl cDzLXU"
       >
-        Mufasa
+        Jazzy Jeff
       </li>
       <li
         className="sc-AxgMl cDzLXU"
       >
-        Pride Rock
+        Independence Day
       </li>
       <li
         className="sc-AxgMl cDzLXU"
       >
-        Nala
+        Jada Pinkett
       </li>
     </ul>
   </div>
@@ -142,6 +177,7 @@ exports[`WatcherGameCard renders correctly 1`] = `
   >
     <button
       className="sc-AxheI sc-AxmLO hTCvJk"
+      disabled={false}
       onClick={[Function]}
     >
       Buzzer!

--- a/src/components/GameInfo/GameInfo.js
+++ b/src/components/GameInfo/GameInfo.js
@@ -40,15 +40,6 @@ class GameInfo extends React.Component {
 			},
 		]
 
-		//dummy data - to be retrieved from firebase using gamecode
-		const players = [
-            { id: 12345, name: "Alexa", team: "team1" },
-            { id: 12346, name: "Stephen", team: "team1" },
-            { id: 12347, name: "Yumani", team: "team2" },
-            { id: 12348, name: "Faith", team: "team1" },
-            { id: 12349, name: "Lisa", team: "team2" },
-            { id: 12340, name: "Danielle", team: "team2" },
-          ]
 
 		const { showRules, showTeams } = this.state
 
@@ -57,7 +48,7 @@ class GameInfo extends React.Component {
 				{<Button {...buttonInfo[0]} />}
 				{<Button {...buttonInfo[1]} />}
 				{showRules && <Rules toggleGameInfo={this.toggleGameInfo} />}
-				{showTeams && <PlayerListCard players={players} currentPlayer="12349" />}
+				{showTeams && <PlayerListCard players={this.props.players} currentPlayer={this.props.currentPlayer} />}
 			</StyledGameInfo>
 		)
 	}

--- a/src/components/GameInfo/__tests__/GameInfo.test.js
+++ b/src/components/GameInfo/__tests__/GameInfo.test.js
@@ -1,50 +1,74 @@
 import React from 'react'
 import renderer from 'react-test-renderer'
-import { shallow, mount } from "enzyme"
+import { shallow } from 'enzyme'
 import { ThemeProvider } from 'styled-components'
 import theme from '../../../global-design/theme'
 import GameInfo from '../GameInfo'
 import Rules from 'components/Rules'
 import PlayerListCard from 'components/PlayerListCard'
+import { Button } from 'components/shared/Button'
 
-test('renders correctly', () => {
-	const wrapper = renderer
-		.create(
-			<ThemeProvider theme={theme}>
-				<GameInfo />
-			</ThemeProvider>
+describe('Game Info rendering and functionality', () => {
+	const defaultProps = {
+		players: [
+			{ name: 'Player 1', playerId: '12345', team: 'team 1' },
+			{ name: 'Player 2', playerId: '23456', team: 'team 1' },
+			{ name: 'Player 3', playerId: '34567', team: 'team 2' },
+			{ name: 'Player 4', playerId: '45678', team: 'team 2' },
+		],
+		currentPlayer: { name: 'Player 1', playerId: '12345', team: 'team 1' },
+    }
+    
+    const mockEvent = {
+        target: {
+            name: ""
+        }
+    }
+
+	test('renders correctly', () => {
+		const props = {
+			...defaultProps,
+		}
+		const wrapper = renderer
+			.create(
+				<ThemeProvider theme={theme}>
+					<GameInfo {...props} />
+				</ThemeProvider>
+			)
+			.toJSON()
+
+		expect(wrapper).toMatchSnapshot()
+	})
+
+	test('contains 2 Buttons and no Rules or PlayerListCard components by default', () => {
+		const props = {
+			...defaultProps,
+		}
+		const wrapper = shallow(
+				<GameInfo {...props} />
 		)
-		.toJSON()
 
-	expect(wrapper).toMatchSnapshot()
-})
+		expect(wrapper.dive().find(Button)).toHaveLength(2)
+		expect(wrapper.dive().find(Rules)).toHaveLength(0)
+		expect(wrapper.dive().find(PlayerListCard)).toHaveLength(0)
+	})
 
-test("contains 2 buttons when showRules and showTeams state are false", () => {
-    const wrapper = mount(
-        <ThemeProvider theme={theme}>
-            <GameInfo />
-        </ThemeProvider>
-    )
+	test('Rules and PlayerListCard components render when Show buttons clicked', () => {
+		const props = {
+			...defaultProps,
+		}
+		const wrapper = shallow(
+				<GameInfo {...props} />
+		)
 
-    expect(wrapper.find("button")).toHaveLength(2)
-    expect(wrapper.find("button").at(0).text()).toEqual("Show Rules")
-    expect(wrapper.find("button").at(1).text()).toEqual("Show Teams")
-    expect(wrapper.find(Rules)).toHaveLength(0)
-    expect(wrapper.find(PlayerListCard)).toHaveLength(0)
-})
-
-test("Rules and Team Card displays when Show buttons clicked", () => {
-    const wrapper = mount(
-        <ThemeProvider theme={theme}>
-            <GameInfo />
-        </ThemeProvider>
-    )
-
-    //Click each button
-    wrapper.find("button").at(0).simulate("click")    
-    wrapper.find("button").at(1).simulate("click")
-    expect(wrapper.find(GameInfo).state("showRules")).toBe(true)
-    expect(wrapper.find(GameInfo).state("showTeams")).toBe(true)
-    expect(wrapper.find(Rules)).toHaveLength(1)
-    expect(wrapper.find(PlayerListCard)).toHaveLength(1)
+        //Call method that is called when button is clicked. Calling method directly instead of click to avoid using mount()
+        mockEvent.target.name = "showRules"
+        wrapper.instance().toggleGameInfo(mockEvent)
+        
+        mockEvent.target.name = "showTeams"
+        wrapper.instance().toggleGameInfo(mockEvent)
+     
+		expect(wrapper.dive().find(Rules)).toHaveLength(1)
+		expect(wrapper.dive().find(PlayerListCard)).toHaveLength(1)      
+	})
 })

--- a/src/components/GameInfo/__tests__/__snapshots__/GameInfo.test.js.snap
+++ b/src/components/GameInfo/__tests__/__snapshots__/GameInfo.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders correctly 1`] = `
+exports[`Game Info rendering and functionality renders correctly 1`] = `
 <div
   className="sc-fzqNJr jAYKSu"
   open={false}

--- a/src/components/InRound/InRound.js
+++ b/src/components/InRound/InRound.js
@@ -1,8 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
-import { firestoreConnect } from 'react-redux-firebase'
-import { compose } from 'redux'
 import TimeCard from 'components/TimeCard'
 import { GiverGameCard, WatcherGameCard, TeamGameCard } from 'components/GameCard'
 import { changeCardStatus } from 'store/actions/roundActions'
@@ -21,29 +19,14 @@ Information needed:
 - timeup callback
 
 */
-const InRound = ({ role, giver, watcher, changeCardStatus }) => {
-	//  ({ giver, watcher, role, changeCardStatus }) => {
-
-	// changeCardStatus = (status) => {
-	// 	//get current index
-	// 	//update status based on status and store round number
-	// 	//store in cardsPlayed array?
-	// 	//increment index
-	// 	console.log(status)
-	// 	console.log(props)
-
-	// 	// const {gamecode} = this.props.match.params
-	// 	// const { cardIndex, round } = this.props.gameplay
-
-	// 	// this.props.changeCardStatus(gamecode, status, round, cardIndex)
-	// }
-
-	
+const InRound = ({ deck, cardIndex, role, giver, watcher, isPending, changeCardStatus }) => {
+	const currentCard = deck[cardIndex]
+	console.log(currentCard)
 	return (
 		<React.Fragment>
 			<TimeCard timeRemaining={'2:00'} timeUp={() => console.log('time up')} />
-			{role === 'giver' && <GiverGameCard changeCardStatus={changeCardStatus} />}
-			{role === 'watcher' && <WatcherGameCard changeCardStatus={changeCardStatus} />}
+			{role === 'giver' && <GiverGameCard currentCard={currentCard} changeCardStatus={changeCardStatus} isPending={isPending} />}
+			{role === 'watcher' && <WatcherGameCard currentCard={currentCard} changeCardStatus={changeCardStatus} isPending={isPending} />}
 			{(role === 'giverTeam' || role === 'watcherTeam') && (
 				<TeamGameCard role={role} giver={giver} watcher={watcher} />
 			)}
@@ -56,20 +39,20 @@ InRound.propTypes = {
 	watcher: PropTypes.object.isRequired,
 	role: PropTypes.string,
 }
-/*
-const mapStateToProps = (state, prevProps) => {
-	const game = state.firestore.data?.games?.[prevProps.match.params.gamecode]
-	console.log(game)
+
+const mapStateToProps = (state) => {
+	console.log(state)
+	
 	// console.log(state.firestore.data)
 	return {
-		gamecode: state.game.gamecode, //tbd if adding this
-		game: game ? game : {}, //from firestore
-		gameDataReceived: state.firestore.status.requested[`games/${prevProps.match.params.gamecode}`],
+		isPending: state.round.pending,
+		error: state.round.error,
 	}
-}*/
+}
+
 
 const mapDispatchToProps = (dispatch, prevProps) => {
-	console.log(prevProps)
+	//The index of the currently displayed card, current round and gamecode
 	const { cardIndex, round, gamecode } = prevProps
 	return {
 		changeCardStatus: (status) => {
@@ -78,4 +61,4 @@ const mapDispatchToProps = (dispatch, prevProps) => {
 	}
 }
 
-export default connect(null, mapDispatchToProps)(InRound)
+export default connect(mapStateToProps, mapDispatchToProps)(InRound)

--- a/src/components/InRound/InRound.js
+++ b/src/components/InRound/InRound.js
@@ -1,7 +1,11 @@
 import React from 'react'
-import PropTypes from "prop-types"
+import PropTypes from 'prop-types'
+import { connect } from 'react-redux'
+import { firestoreConnect } from 'react-redux-firebase'
+import { compose } from 'redux'
 import TimeCard from 'components/TimeCard'
 import { GiverGameCard, WatcherGameCard, TeamGameCard } from 'components/GameCard'
+import { changeCardStatus } from 'store/actions/roundActions'
 
 /*
 Information needed:
@@ -17,14 +21,29 @@ Information needed:
 - timeup callback
 
 */
-const InRound = ({ giver, watcher, role = 'watcherTeam' }) => {
-	console.log(giver, watcher)
-	console.log(role)
+const InRound = ({ role, giver, watcher, changeCardStatus }) => {
+	//  ({ giver, watcher, role, changeCardStatus }) => {
+
+	// changeCardStatus = (status) => {
+	// 	//get current index
+	// 	//update status based on status and store round number
+	// 	//store in cardsPlayed array?
+	// 	//increment index
+	// 	console.log(status)
+	// 	console.log(props)
+
+	// 	// const {gamecode} = this.props.match.params
+	// 	// const { cardIndex, round } = this.props.gameplay
+
+	// 	// this.props.changeCardStatus(gamecode, status, round, cardIndex)
+	// }
+
+	
 	return (
 		<React.Fragment>
 			<TimeCard timeRemaining={'2:00'} timeUp={() => console.log('time up')} />
-			{role === 'giver' && <GiverGameCard />}
-			{role === 'watcher' && <WatcherGameCard />}
+			{role === 'giver' && <GiverGameCard changeCardStatus={changeCardStatus} />}
+			{role === 'watcher' && <WatcherGameCard changeCardStatus={changeCardStatus} />}
 			{(role === 'giverTeam' || role === 'watcherTeam') && (
 				<TeamGameCard role={role} giver={giver} watcher={watcher} />
 			)}
@@ -35,6 +54,28 @@ const InRound = ({ giver, watcher, role = 'watcherTeam' }) => {
 InRound.propTypes = {
 	giver: PropTypes.object.isRequired,
 	watcher: PropTypes.object.isRequired,
-	role: PropTypes.string
+	role: PropTypes.string,
 }
-export default InRound
+/*
+const mapStateToProps = (state, prevProps) => {
+	const game = state.firestore.data?.games?.[prevProps.match.params.gamecode]
+	console.log(game)
+	// console.log(state.firestore.data)
+	return {
+		gamecode: state.game.gamecode, //tbd if adding this
+		game: game ? game : {}, //from firestore
+		gameDataReceived: state.firestore.status.requested[`games/${prevProps.match.params.gamecode}`],
+	}
+}*/
+
+const mapDispatchToProps = (dispatch, prevProps) => {
+	console.log(prevProps)
+	const { cardIndex, round, gamecode } = prevProps
+	return {
+		changeCardStatus: (status) => {
+			dispatch(changeCardStatus(gamecode, status, round, cardIndex))
+		},
+	}
+}
+
+export default connect(null, mapDispatchToProps)(InRound)

--- a/src/components/InRound/InRound.js
+++ b/src/components/InRound/InRound.js
@@ -2,7 +2,6 @@ import React from 'react'
 import PropTypes from "prop-types"
 import TimeCard from 'components/TimeCard'
 import { GiverGameCard, WatcherGameCard, TeamGameCard } from 'components/GameCard'
-import ScoreCard from 'components/ScoreCard'
 
 /*
 Information needed:
@@ -20,6 +19,7 @@ Information needed:
 */
 const InRound = ({ giver, watcher, role = 'watcherTeam' }) => {
 	console.log(giver, watcher)
+	console.log(role)
 	return (
 		<React.Fragment>
 			<TimeCard timeRemaining={'2:00'} timeUp={() => console.log('time up')} />
@@ -33,8 +33,8 @@ const InRound = ({ giver, watcher, role = 'watcherTeam' }) => {
 }
 
 InRound.propTypes = {
-	giver: PropTypes.string.isRequired,
-	watcher: PropTypes.string.isRequired,
+	giver: PropTypes.object.isRequired,
+	watcher: PropTypes.object.isRequired,
 	role: PropTypes.string
 }
 export default InRound

--- a/src/components/InRound/InRound.js
+++ b/src/components/InRound/InRound.js
@@ -19,14 +19,18 @@ Information needed:
 - timeup callback
 
 */
-const InRound = ({ deck, cardIndex, role, giver, watcher, isPending, changeCardStatus }) => {
+export const InRound = ({ deck, cardIndex, role, giver, watcher, isPending, changeCardStatus }) => {
 	const currentCard = deck[cardIndex]
 	console.log(currentCard)
 	return (
 		<React.Fragment>
 			<TimeCard timeRemaining={'2:00'} timeUp={() => console.log('time up')} />
-			{role === 'giver' && <GiverGameCard currentCard={currentCard} changeCardStatus={changeCardStatus} isPending={isPending} />}
-			{role === 'watcher' && <WatcherGameCard currentCard={currentCard} changeCardStatus={changeCardStatus} isPending={isPending} />}
+			{role === 'giver' && (
+				<GiverGameCard currentCard={currentCard} changeCardStatus={changeCardStatus} isPending={isPending} />
+			)}
+			{role === 'watcher' && (
+				<WatcherGameCard currentCard={currentCard} changeCardStatus={changeCardStatus} isPending={isPending} />
+			)}
 			{(role === 'giverTeam' || role === 'watcherTeam') && (
 				<TeamGameCard role={role} giver={giver} watcher={watcher} />
 			)}
@@ -37,19 +41,22 @@ const InRound = ({ deck, cardIndex, role, giver, watcher, isPending, changeCardS
 InRound.propTypes = {
 	giver: PropTypes.object.isRequired,
 	watcher: PropTypes.object.isRequired,
-	role: PropTypes.string,
+	role: PropTypes.string.isRequired,
+	deck: PropTypes.object.isRequired,
+	cardIndex: PropTypes.number.isRequired,
+	isPending: PropTypes.bool.isRequired,
+	changeCardStatus: PropTypes.func.isRequired,
 }
 
 const mapStateToProps = (state) => {
 	console.log(state)
-	
+
 	// console.log(state.firestore.data)
 	return {
 		isPending: state.round.pending,
 		error: state.round.error,
 	}
 }
-
 
 const mapDispatchToProps = (dispatch, prevProps) => {
 	//The index of the currently displayed card, current round and gamecode

--- a/src/components/InRound/__tests__/InRound.test.js
+++ b/src/components/InRound/__tests__/InRound.test.js
@@ -1,79 +1,107 @@
-import React from "react"
-import renderer from "react-test-renderer"
-import { mount } from 'enzyme'
+import React from 'react'
+import renderer from 'react-test-renderer'
+import { shallow } from 'enzyme'
 import { ThemeProvider } from 'styled-components'
 import theme from '../../../global-design/theme'
-import InRound from "../InRound"
+import { InRound } from '../InRound'
 import TimeCard from 'components/TimeCard'
 import { GiverGameCard, WatcherGameCard, TeamGameCard } from 'components/GameCard'
 
+describe('Inround rendering and functionality', () => {
+	const defaultProps = {
+		giver: { name: 'Sam', playerId: '12345', team: 'team 1' },
+		watcher: { name: 'Jo', playerId: '23456', team: 'team 2' },
+		role: 'giver',
+		deck: {
+			0: {
+				word: 'apple',
+				tabooList: ['red', 'shiny', 'round', 'fruit', 'Eve'],
+			},
+			1: {
+				word: 'banana',
+				tabooList: ['yellow', 'fruit', 'monkey', 'peel', 'slip'],
+			},
+			2: {
+				word: 'strawberry',
+				tabooList: ['red', 'green', 'fruit', 'shortcake', 'cheesecake'],
+			},
+		},
+		cardIndex: 0,
+		isPending: false,
+		changeCardStatus: jest.fn(),
+	}
 
+	test('renders correctly', () => {
+		const props = {
+			...defaultProps,
+		}
 
-test("renders correctly", () => {
-    const props = {
-        giver: "Sam",
-        watcher: "Jo",
-        role: "giverTeam" 
-    }
+		const wrapper = renderer
+			.create(
+				<ThemeProvider theme={theme}>
+					<InRound {...props} />
+				</ThemeProvider>
+			)
+			.toJSON()
+		expect(wrapper).toMatchSnapshot()
+	})
 
-    const wrapper = renderer.create(
-        <ThemeProvider theme={theme}>
-            <InRound {...props} />
-            </ThemeProvider>).toJSON()
-    expect(wrapper).toMatchSnapshot()
-})
+	test('renders TimeCard and GiverGame card when role is giver', () => {
+		const props = {
+			...defaultProps,
+		}
 
-test("renders TimeCard and GiverGame card when role is giver", () => {
-    const props = {
-        giver: "Sam",
-        watcher: "Jo",
-        role: "giver" 
-    }
+		const wrapper = shallow(<InRound {...props} />)
 
-    const wrapper = mount(
-        <ThemeProvider theme ={theme}>
-            <InRound {...props} />
-        </ThemeProvider>)
+		expect(wrapper.find(TimeCard)).toHaveLength(1)
+		expect(wrapper.find(GiverGameCard)).toHaveLength(1)
+		expect(wrapper.find(WatcherGameCard)).toHaveLength(0)
+		expect(wrapper.find(TeamGameCard)).toHaveLength(0)
+	})
 
-        expect(wrapper.find(TimeCard)).toHaveLength(1)
-        expect(wrapper.find(GiverGameCard)).toHaveLength(1)
-        expect(wrapper.find(WatcherGameCard)).toHaveLength(0)
-        expect(wrapper.find(TeamGameCard)).toHaveLength(0)
+	test('renders TimeCard and WatcherGameCard when role is watcher', () => {
+		const props = {
+			...defaultProps,
+			role: 'watcher',
+		}
+
+		const wrapper = shallow(<InRound {...props} />)
+
+		expect(wrapper.find(TimeCard)).toHaveLength(1)
+		expect(wrapper.find(WatcherGameCard)).toHaveLength(1)
+		expect(wrapper.find(GiverGameCard)).toHaveLength(0)
+		expect(wrapper.find(TeamGameCard)).toHaveLength(0)
+	})
+
+	test('renders TimeCard and TeamGameCard when role is giverTeam', () => {
+		const props = {
+			...defaultProps,
+			role: 'giverTeam',
+		}
+
+		const wrapper = shallow(
+				<InRound {...props} />
+		)
+
+		expect(wrapper.find(TimeCard)).toHaveLength(1)
+		expect(wrapper.find(TeamGameCard)).toHaveLength(1)
+		expect(wrapper.find(WatcherGameCard)).toHaveLength(0)
+		expect(wrapper.find(GiverGameCard)).toHaveLength(0)
     })
+    
+    test('renders TimeCard and TeamGameCard when role is watcherTeam', () => {
+		const props = {
+			...defaultProps,
+			role: 'watcherTeam',
+		}
 
-    test("renders TimeCard and WatcherGameCard when role is watcher", () => {
-        const props = {
-            giver: "Sam",
-            watcher: "Jo",
-            role: "watcher" 
-        }
-    
-        const wrapper = mount(
-            <ThemeProvider theme ={theme}>
-                <InRound {...props} />
-            </ThemeProvider>)
-    
-            expect(wrapper.find(TimeCard)).toHaveLength(1)
-            expect(wrapper.find(WatcherGameCard)).toHaveLength(1)
-            expect(wrapper.find(GiverGameCard)).toHaveLength(0)
-            expect(wrapper.find(TeamGameCard)).toHaveLength(0)
-        })
+		const wrapper = shallow(
+				<InRound {...props} />
+		)
 
-        
-    test("renders TimeCard and TeamGameCard when role is giverTeam or watcherTeam", () => {
-        const props = {
-            giver: "Sam",
-            watcher: "Jo",
-            role: "giverTeam" 
-        }
-    
-        const wrapper = mount(
-            <ThemeProvider theme ={theme}>
-                <InRound {...props} />
-            </ThemeProvider>)
-    
-            expect(wrapper.find(TimeCard)).toHaveLength(1)
-            expect(wrapper.find(TeamGameCard)).toHaveLength(1)
-            expect(wrapper.find(WatcherGameCard)).toHaveLength(0)
-            expect(wrapper.find(GiverGameCard)).toHaveLength(0)
-        })
+		expect(wrapper.find(TimeCard)).toHaveLength(1)
+		expect(wrapper.find(TeamGameCard)).toHaveLength(1)
+		expect(wrapper.find(WatcherGameCard)).toHaveLength(0)
+		expect(wrapper.find(GiverGameCard)).toHaveLength(0)
+	})
+})

--- a/src/components/InRound/__tests__/__snapshots__/InRound.test.js.snap
+++ b/src/components/InRound/__tests__/__snapshots__/InRound.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders correctly 1`] = `
+exports[`Inround rendering and functionality renders correctly 1`] = `
 Array [
   <div
     className="sc-AxjAm ldGgOs"
@@ -16,25 +16,58 @@ Array [
     <div
       className="sc-AxhUy flvuPt"
     >
-      Guess!
+      apple
     </div>
     <div
       className="sc-AxgMl fmQkUd"
     >
-      <p
-        className="sc-fznyAO irPvyr"
+      <ul
+        className="sc-AxheI dpNzUY"
       >
-        It's your teams turn to guess the word! 
-        <span
-          className="sc-fznKkj dDFvLm"
-        />
-         is giving the clues and
-         
-        <span
-          className="sc-fznKkj dDFvLm"
-        />
-         will be making sure they don't say anything Taboo!
-      </p>
+        <li
+          className="sc-Axmtr eKdZYh"
+        >
+          red
+        </li>
+        <li
+          className="sc-Axmtr eKdZYh"
+        >
+          shiny
+        </li>
+        <li
+          className="sc-Axmtr eKdZYh"
+        >
+          round
+        </li>
+        <li
+          className="sc-Axmtr eKdZYh"
+        >
+          fruit
+        </li>
+        <li
+          className="sc-Axmtr eKdZYh"
+        >
+          Eve
+        </li>
+      </ul>
+    </div>
+    <div
+      className="sc-fzplWN buDbqD"
+    >
+      <button
+        className="sc-AxmLO cmqLOv"
+        disabled={false}
+        onClick={[Function]}
+      >
+        Skip!
+      </button>
+      <button
+        className="sc-AxmLO sc-fzozJi ZeZOx"
+        disabled={false}
+        onClick={[Function]}
+      >
+        Next!
+      </button>
     </div>
   </div>,
 ]

--- a/src/components/JoinGame/JoinGame.js
+++ b/src/components/JoinGame/JoinGame.js
@@ -65,7 +65,7 @@ export class JoinGame extends React.Component {
 		]
 
 		return this.state.redirect ? (
-			<Redirect to={`/waiting/${this.props.gamecode}`} />
+			<Redirect to={`/waiting/${this.state.gamecode}`} />
 		) : (
 			<ButtonTabooCard tabooWord="Join Game" buttons={buttonInfo}>
 				<JoinGameForm initialValues={{ name, gamecode }} handleSubmit={this.handleSubmit} />
@@ -80,7 +80,6 @@ JoinGame.propTypes = {
 	history: PropTypes.object.isRequired,
 	error: PropTypes.object,
 	isPending: PropTypes.bool.isRequired,
-	gamecode: PropTypes.string.isRequired,
 	joinNewGame: PropTypes.func.isRequired,
 	clearGameErrors: PropTypes.func.isRequired,
 }
@@ -90,7 +89,6 @@ const mapStateToProps = (state) => {
 	return {
 		error: state.game.error ? state.game.error.errorMessage : state.game.error,
 		isPending: state.game.pending,
-		gamecode: state.game.gamecode,
 	}
 }
 

--- a/src/components/PreRound/PreRound.js
+++ b/src/components/PreRound/PreRound.js
@@ -4,6 +4,7 @@ import RoundInstructionsCard from "components/RoundInstructionsCard"
 import ScoreCard from "components/ScoreCard"
 
 const PreRound = (props) => {
+  console.log(props)
   return (
     <React.Fragment>
       <ScoreCard teamScores={[2, 3]} />
@@ -14,7 +15,8 @@ const PreRound = (props) => {
 
 
 PreRound.propTypes = {
-  role:PropTypes.string.isRequired,
+  activeTeam:PropTypes.string.isRequired,
+  currentPlayer: PropTypes.object.isRequired,
   giver:PropTypes.object.isRequired,
   watcher:PropTypes.object.isRequired,
   startRound : PropTypes.func.isRequired

--- a/src/components/PreRound/PreRound.js
+++ b/src/components/PreRound/PreRound.js
@@ -4,7 +4,6 @@ import RoundInstructionsCard from "components/RoundInstructionsCard"
 import ScoreCard from "components/ScoreCard"
 
 const PreRound = (props) => {
-  console.log(props)
   return (
     <React.Fragment>
       <ScoreCard teamScores={[2, 3]} />
@@ -15,8 +14,7 @@ const PreRound = (props) => {
 
 
 PreRound.propTypes = {
-  activeTeam:PropTypes.string.isRequired,
-  currentPlayer: PropTypes.object.isRequired,
+  role: PropTypes.string.isRequired,
   giver:PropTypes.object.isRequired,
   watcher:PropTypes.object.isRequired,
   startRound : PropTypes.func.isRequired

--- a/src/components/PreRound/__tests__/PreRound.test.js
+++ b/src/components/PreRound/__tests__/PreRound.test.js
@@ -1,14 +1,17 @@
 import React from 'react'
 import renderer from 'react-test-renderer'
-import PreRound from '../PreRound'
+import { shallow } from "enzyme"
 import { ThemeProvider } from 'styled-components'
 import theme from '../../../global-design/theme'
+import PreRound from '../PreRound'
+import RoundInstructionsCard from "components/RoundInstructionsCard"
+import ScoreCard from "components/ScoreCard"
 
 test('PreRound renders correctly', () => {
 	const props = {
 		role: 'watcherTeam',
-		giver: { name: 'Danielle', playerId: 123 },
-		watcher: { name: 'Stephen', playerId: 345 },
+		giver: { name: 'Danielle', playerId: "12345", team: 'team 1' },
+		watcher: { name: 'Stephen', playerId: "34567", team: 'team 1' },
 		startRound: jest.fn(),
 	}
 	const wrapper = renderer
@@ -19,4 +22,18 @@ test('PreRound renders correctly', () => {
 		)
 		.toJSON()
 	expect(wrapper).toMatchSnapshot()
+})
+
+test('PreRound renders a ScoreCard and RoundInstructionsCard', () => {
+	const props = {
+		role: 'watcherTeam',
+		giver: { name: 'Danielle', playerId: "12345", team: 'team 1' },
+		watcher: { name: 'Stephen', playerId: "34567", team: 'team 1' },
+		startRound: jest.fn(),
+	}
+	const wrapper = shallow(<PreRound {...props} />)
+							
+	expect(wrapper.find(ScoreCard)).toHaveLength(1)
+	expect(wrapper.find(RoundInstructionsCard)).toHaveLength(1)
+
 })

--- a/src/components/PreRound/__tests__/__snapshots__/PreRound.test.js.snap
+++ b/src/components/PreRound/__tests__/__snapshots__/PreRound.test.js.snap
@@ -55,8 +55,8 @@ Array [
         >
           Danielle
         </span>
+         will be giving the clues, and
          
-        will be giving the clues, and 
         <span
           className="sc-fzplWN kxXpQP"
         >

--- a/src/components/Round/Round.js
+++ b/src/components/Round/Round.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import { connect } from 'react-redux'
 import GameInfo from 'components/GameInfo'
 import PreRound from 'components/PreRound'
 import InRound from 'components/InRound'
@@ -6,6 +7,8 @@ import PostRound from 'components/PostRound'
 import RoundInfo from 'components/RoundInfo'
 import Pending from 'components/shared/Pending'
 import ErrorMessage from 'components/shared/ErrorMessage'
+import { updateRoundStatus } from 'store/actions/roundActions'
+
 class Round extends React.Component {
 	constructor(props) {
 		super(props)
@@ -29,7 +32,6 @@ class Round extends React.Component {
 
 	determineActivePlayer = (role) => {
 		let activePlayer
-
 		const { half, team1Turn, team2Turn } = this.props.gameplay
 		if (role === 'giver') {
 			activePlayer = half === 'top' ? this.state.team1[team1Turn] : this.state.team2[team2Turn]
@@ -41,7 +43,7 @@ class Round extends React.Component {
 	}
 
 	startRound = () => {
-		console.log('start round')
+		this.props.updateRoundStatus(this.props.gamecode, 'in progress')
 	}
 
 	render() {
@@ -51,33 +53,55 @@ class Round extends React.Component {
 			//Update with actual loading component
 			return <p>Loading Firestore/Firebase</p>
 		} else {
-            console.log(this.props)
+			console.log(this.props)
 			const { round, half, status } = this.props.gameplay
 			const activeTeam = half === 'top' ? 'team 1' : 'team 2'
 			const giver = this.determineActivePlayer('giver')
-            const watcher = this.determineActivePlayer('watcher')
-            const currentPlayer = this.props.players.find((player) => player.playerId === this.props.playerId )
+			const watcher = this.determineActivePlayer('watcher')
+			const currentPlayer = this.props.players.find((player) => player.playerId === this.props.playerId)
+			let role
+			if (activeTeam === currentPlayer.team) {
+				role = currentPlayer.playerId === giver.playerId ? 'giver' : 'giverTeam'
+			} else {
+				role = currentPlayer.playerId === giver.playerId ? 'watcher' : 'watcherTeam'
+			}
 			return (
-				<>
-					<GameInfo players={this.props.players} currentPlayer={currentPlayer}/>
+				<React.Fragment>
+					<GameInfo players={this.props.players} currentPlayer={currentPlayer} />
 					<RoundInfo round={round} watcher={watcher} giver={giver} />
 
 					{status === 'preround' && (
 						<PreRound
+							startRound={this.startRound}
+							currentPlayer={currentPlayer}
+							giver={giver}
+							watcher={watcher}
+							role={role}
+						/>
+					)}
+					{status === 'inprogress' && (
+						<InRound
 							activeTeam={activeTeam}
 							startRound={this.startRound}
 							currentPlayer={currentPlayer}
 							giver={giver}
 							watcher={watcher}
+							role={role}
 						/>
 					)}
-					{/* {gameplay.status === 'inprogress' && <InRound {...dummyRoundData} />}
-				{gameplay.status === 'postround' && <PostRound cardsPlayed={dummyPostRoundData} />}
-                */}
-				</>
+					{/*   {gameplay.status === 'postround' && <PostRound cardsPlayed={dummyPostRoundData} />}
+					 */}
+				</React.Fragment>
 			)
 		}
 	}
 }
 
-export default Round
+const mapDispatchToProps = (dispatch) => {
+	return {
+		updateRoundStatus: (gamecode, newStatus) => {
+			dispatch(updateRoundStatus(gamecode, newStatus))
+		},
+	}
+}
+export default connect(null, mapDispatchToProps)(Round)

--- a/src/components/Round/Round.js
+++ b/src/components/Round/Round.js
@@ -1,0 +1,83 @@
+import React from 'react'
+import GameInfo from 'components/GameInfo'
+import PreRound from 'components/PreRound'
+import InRound from 'components/InRound'
+import PostRound from 'components/PostRound'
+import RoundInfo from 'components/RoundInfo'
+import Pending from 'components/shared/Pending'
+import ErrorMessage from 'components/shared/ErrorMessage'
+class Round extends React.Component {
+	constructor(props) {
+		super(props)
+
+		this.state = {
+			loading: true,
+			team1: [],
+			team2: [],
+		}
+	}
+
+	componentDidMount() {
+		//Get the initial giver and watcher
+		console.log('mounting...')
+		this.setState({
+			loading: false,
+			team1: this.props.players.filter((player) => player.team === 'team 1'),
+			team2: this.props.players.filter((player) => player.team === 'team 2'),
+		})
+	}
+
+	determineActivePlayer = (role) => {
+		let activePlayer
+
+		const { half, team1Turn, team2Turn } = this.props.gameplay
+		if (role === 'giver') {
+			activePlayer = half === 'top' ? this.state.team1[team1Turn] : this.state.team2[team2Turn]
+		} else {
+			activePlayer = half === 'top' ? this.state.team2[team2Turn] : this.state.team1[team1Turn]
+		}
+		console.log(activePlayer)
+		return activePlayer
+	}
+
+	startRound = () => {
+		console.log('start round')
+	}
+
+	render() {
+		console.log(this.props)
+
+		if (this.state.loading) {
+			//Update with actual loading component
+			return <p>Loading Firestore/Firebase</p>
+		} else {
+            console.log(this.props)
+			const { round, half, status } = this.props.gameplay
+			const activeTeam = half === 'top' ? 'team 1' : 'team 2'
+			const giver = this.determineActivePlayer('giver')
+            const watcher = this.determineActivePlayer('watcher')
+            const currentPlayer = this.props.players.find((player) => player.playerId === this.props.playerId )
+			return (
+				<>
+					<GameInfo players={this.props.players} currentPlayer={currentPlayer}/>
+					<RoundInfo round={round} watcher={watcher} giver={giver} />
+
+					{status === 'preround' && (
+						<PreRound
+							activeTeam={activeTeam}
+							startRound={this.startRound}
+							currentPlayer={currentPlayer}
+							giver={giver}
+							watcher={watcher}
+						/>
+					)}
+					{/* {gameplay.status === 'inprogress' && <InRound {...dummyRoundData} />}
+				{gameplay.status === 'postround' && <PostRound cardsPlayed={dummyPostRoundData} />}
+                */}
+				</>
+			)
+		}
+	}
+}
+
+export default Round

--- a/src/components/Round/Round.js
+++ b/src/components/Round/Round.js
@@ -57,7 +57,7 @@ class Round extends React.Component {
 			return <p>Loading Firestore/Firebase</p>
 		} else {
 			const { gamecode } = this.props
-			const { round, half, status, cardIndex } = this.props.gameplay
+			const { round, half, status, cardIndex, deck } = this.props.gameplay
 			const activeTeam = half === 'top' ? 'team 1' : 'team 2'
 			const giver = this.determineActivePlayer('giver')
 			const watcher = this.determineActivePlayer('watcher')
@@ -90,6 +90,7 @@ class Round extends React.Component {
 							watcher={watcher}
 							role={role}
 							round={round}
+							deck={deck}
 							cardIndex={cardIndex}
 						/>
 					)}

--- a/src/components/Round/Round.js
+++ b/src/components/Round/Round.js
@@ -17,14 +17,14 @@ class Round extends React.Component {
 			loading: true,
 			team1: [],
 			team2: [],
-			cardsPlayed: []
+			cardsPlayed: [],
 		}
 	}
 
 	componentDidMount() {
 		//Get the initial giver and watcher
 		console.log('mounting...')
-		
+
 		this.setState({
 			loading: false,
 			team1: this.props.players.filter((player) => player.team === 'team 1'),
@@ -45,7 +45,7 @@ class Round extends React.Component {
 	}
 
 	startRound = () => {
-		console.log("Start round")
+		console.log('Start round')
 		this.props.updateRoundStatus(this.props.gamecode, 'in progress')
 	}
 
@@ -56,8 +56,8 @@ class Round extends React.Component {
 			//Update with actual loading component
 			return <p>Loading Firestore/Firebase</p>
 		} else {
-			console.log(this.props)
-			const { round, half, status } = this.props.gameplay
+			const { gamecode } = this.props
+			const { round, half, status, cardIndex } = this.props.gameplay
 			const activeTeam = half === 'top' ? 'team 1' : 'team 2'
 			const giver = this.determineActivePlayer('giver')
 			const watcher = this.determineActivePlayer('watcher')
@@ -83,11 +83,14 @@ class Round extends React.Component {
 						/>
 					)}
 					{status === 'in progress' && (
-						<InRound			
+						<InRound
+							gamecode={gamecode}
 							currentPlayer={currentPlayer}
 							giver={giver}
 							watcher={watcher}
 							role={role}
+							round={round}
+							cardIndex={cardIndex}
 						/>
 					)}
 					{/*   {gameplay.status === 'postround' && <PostRound cardsPlayed={dummyPostRoundData} />}

--- a/src/components/Round/Round.js
+++ b/src/components/Round/Round.js
@@ -17,12 +17,14 @@ class Round extends React.Component {
 			loading: true,
 			team1: [],
 			team2: [],
+			cardsPlayed: []
 		}
 	}
 
 	componentDidMount() {
 		//Get the initial giver and watcher
 		console.log('mounting...')
+		
 		this.setState({
 			loading: false,
 			team1: this.props.players.filter((player) => player.team === 'team 1'),

--- a/src/components/Round/Round.js
+++ b/src/components/Round/Round.js
@@ -45,6 +45,7 @@ class Round extends React.Component {
 	}
 
 	startRound = () => {
+		console.log("Start round")
 		this.props.updateRoundStatus(this.props.gamecode, 'in progress')
 	}
 
@@ -65,7 +66,7 @@ class Round extends React.Component {
 			if (activeTeam === currentPlayer.team) {
 				role = currentPlayer.playerId === giver.playerId ? 'giver' : 'giverTeam'
 			} else {
-				role = currentPlayer.playerId === giver.playerId ? 'watcher' : 'watcherTeam'
+				role = currentPlayer.playerId === watcher.playerId ? 'watcher' : 'watcherTeam'
 			}
 			return (
 				<React.Fragment>
@@ -81,10 +82,8 @@ class Round extends React.Component {
 							role={role}
 						/>
 					)}
-					{status === 'inprogress' && (
-						<InRound
-							activeTeam={activeTeam}
-							startRound={this.startRound}
+					{status === 'in progress' && (
+						<InRound			
 							currentPlayer={currentPlayer}
 							giver={giver}
 							watcher={watcher}

--- a/src/components/Round/index.js
+++ b/src/components/Round/index.js
@@ -1,0 +1,3 @@
+import Round from "./Round"
+
+export default Round

--- a/src/components/RoundInfo/RoundInfo.js
+++ b/src/components/RoundInfo/RoundInfo.js
@@ -3,21 +3,22 @@ import PropTypes from "prop-types"
 import { StyledRoundInfo, RoundNumber, Role } from './style'
 
 const RoundInfo = ({ round, giver, watcher }) => {
+
 	return (
 		<StyledRoundInfo>
 			<RoundNumber>Round: {round}</RoundNumber>
 			<div>
-                <Role>Giver: {giver}</Role>
-                <Role>Watcher: {watcher}</Role>
+                <Role>Giver: {giver.name}</Role>
+                <Role>Watcher: {watcher.name}</Role>
 			</div>
 		</StyledRoundInfo>
 	)
 }
 
 RoundInfo.propTypes = {
-	round: PropTypes.string.isRequired,
-	giver: PropTypes.string.isRequired,
-	watcher: PropTypes.string.isRequired
+	round: PropTypes.number.isRequired,
+	giver: PropTypes.object.isRequired,
+	watcher: PropTypes.object.isRequired
 }
 
 export default RoundInfo

--- a/src/components/RoundInfo/__tests__/RoundInfo.tests.js
+++ b/src/components/RoundInfo/__tests__/RoundInfo.tests.js
@@ -6,9 +6,9 @@ import RoundInfo from '../RoundInfo'
 
 test('RoundInfo renders correctly', () => {
 	const props = {
-		round: '3',
-		giver: 'Sam',
-		watcher: 'Jo',
+		round: 1,
+		giver: { name: 'Sam', playerId: '12345', team: 'team 1' },
+		watcher: { name: 'Jo', playerId: '23456', team: 'team 2' },
 	}
 	const wrapper = renderer
 		.create(

--- a/src/components/RoundInfo/__tests__/RoundInfo.tests.js
+++ b/src/components/RoundInfo/__tests__/RoundInfo.tests.js
@@ -10,6 +10,7 @@ test('RoundInfo renders correctly', () => {
 		giver: { name: 'Sam', playerId: '12345', team: 'team 1' },
 		watcher: { name: 'Jo', playerId: '23456', team: 'team 2' },
 	}
+	
 	const wrapper = renderer
 		.create(
 			<ThemeProvider theme={theme}>

--- a/src/components/RoundInfo/__tests__/__snapshots__/RoundInfo.tests.js.snap
+++ b/src/components/RoundInfo/__tests__/__snapshots__/RoundInfo.tests.js.snap
@@ -8,7 +8,7 @@ exports[`RoundInfo renders correctly 1`] = `
     className="sc-AxirZ ibSLEF"
   >
     Round: 
-    3
+    1
   </p>
   <div>
     <p

--- a/src/components/RoundInstructionsCard/RoundInstructionsCard.js
+++ b/src/components/RoundInstructionsCard/RoundInstructionsCard.js
@@ -3,32 +3,36 @@ import PropTypes from 'prop-types'
 import { TabooCard, ButtonTabooCard } from 'components/shared/TabooCard'
 import { InstructionsText, KeyWord } from './style'
 
-const RoundInstructionsCard = ({ currentPlayer, giver, watcher, startRound }) => {
+const RoundInstructionsCard = ({ role, giver, watcher, startRound }) => {
 	let instructions
-	//On the giving team
-	if (currentPlayer.team === giver.team) {
-		instructions =
-			currentPlayer.playerId === giver.playerId
-				? displayGiverInstructions(watcher, startRound)
-				: displayGiverTeamInstructions(giver, watcher)
-
-		//On the watching team
-	} else {
-    instructions = currentPlayer.playerId === watcher.playerId 
-    ? displayWatcherInstructions(giver)
-    : displayWatcherTeamInstructions(giver, watcher)
-
+	//Determine the instructions based on current player's team and role
+	switch (role) {
+		case 'giver':
+			instructions = displayGiverInstructions(watcher, startRound)
+			break
+		case 'watcher':
+			instructions = displayWatcherInstructions(giver)
+			break
+		case 'giverTeam':
+			instructions = displayGiverTeamInstructions(giver, watcher)
+			break
+		case 'watcherTeam':
+			instructions = displayWatcherTeamInstructions(giver, watcher)
+			break
+		default:
+			instructions = ''
 	}
 
 	return instructions
 }
 
 RoundInstructionsCard.propTypes = {
-	currentPlayer: PropTypes.object.isRequired,
+	role: PropTypes.string.isRequired,
 	giver: PropTypes.object.isRequired,
 	watcher: PropTypes.object.isRequired,
-	startRound: PropTypes.func,
+	startRound: PropTypes.func.isRequired,
 }
+
 const displayGiverInstructions = (watcher, startRound) => {
 	const buttonInfo = [
 		{

--- a/src/components/RoundInstructionsCard/RoundInstructionsCard.js
+++ b/src/components/RoundInstructionsCard/RoundInstructionsCard.js
@@ -1,87 +1,87 @@
-import React from "react"
-import PropTypes from "prop-types"
-import { TabooCard, ButtonTabooCard } from "components/shared/TabooCard"
-import { InstructionsText, KeyWord } from "./style"
+import React from 'react'
+import PropTypes from 'prop-types'
+import { TabooCard, ButtonTabooCard } from 'components/shared/TabooCard'
+import { InstructionsText, KeyWord } from './style'
 
-const RoundInstructionsCard = ({ role, giver, watcher, startRound }) => {
-  switch (role) {
-    case "giver":
-      return displayGiverInstructions(watcher, startRound)
-    case "watcher":
-      return displayWatcherInstructions(giver)
+const RoundInstructionsCard = ({ currentPlayer, giver, watcher, startRound }) => {
+	let instructions
+	//On the giving team
+	if (currentPlayer.team === giver.team) {
+		instructions =
+			currentPlayer.playerId === giver.playerId
+				? displayGiverInstructions(watcher, startRound)
+				: displayGiverTeamInstructions(giver, watcher)
 
-    case "giverTeam":
-      return displayGiverTeamInstructions(giver, watcher)
+		//On the watching team
+	} else {
+    instructions = currentPlayer.playerId === watcher.playerId 
+    ? displayWatcherInstructions(giver)
+    : displayWatcherTeamInstructions(giver, watcher)
 
-    case "watcherTeam":
-      return displayWatcherTeamInstructions(giver, watcher)
+	}
 
-    default:
-      return
-  }
+	return instructions
 }
 
 RoundInstructionsCard.propTypes = {
-  role: PropTypes.string.isRequired,
-  giver: PropTypes.object.isRequired,
-  watcher: PropTypes.object.isRequired,
-  startRound: PropTypes.func
+	currentPlayer: PropTypes.object.isRequired,
+	giver: PropTypes.object.isRequired,
+	watcher: PropTypes.object.isRequired,
+	startRound: PropTypes.func,
 }
 const displayGiverInstructions = (watcher, startRound) => {
-  const buttonInfo = [
-    {
-      text: "Start Round!",
-      onClick: startRound,
-    },
-  ]
-  return (
-    <ButtonTabooCard tabooWord="Get Ready!" buttons={buttonInfo}>
-      <InstructionsText>
-        It’s your turn to give clues to your team!{" "}
-        {<KeyWord>{watcher.name}</KeyWord>} will be making sure you don’t say
-        any taboo words.
-      </InstructionsText>
+	const buttonInfo = [
+		{
+			text: 'Start Round!',
+			onClick: startRound,
+		},
+	]
+	return (
+		<ButtonTabooCard tabooWord="Get Ready!" buttons={buttonInfo}>
+			<InstructionsText>
+				It’s your turn to give clues to your team! {<KeyWord>{watcher.name}</KeyWord>} will be making sure you
+				don’t say any taboo words.
+			</InstructionsText>
 
-      <InstructionsText>
-        Select NEXT if your team guesses the word correctly or SKIP to go to the
-        next card. Make sure to keep an eye on your time!
-      </InstructionsText>
-    </ButtonTabooCard>
-  )
+			<InstructionsText>
+				Select NEXT if your team guesses the word correctly or SKIP to go to the next card. Make sure to keep an
+				eye on your time!
+			</InstructionsText>
+		</ButtonTabooCard>
+	)
 }
 
 const displayWatcherInstructions = (giver) => {
-  return (
-    <TabooCard tabooWord="Get Ready!">
-      <InstructionsText>
-        It’s the other team’s turn to give clues! You are the watcher for this
-        round! If {<KeyWord>{giver.name}</KeyWord>} says any words from the
-        taboo list or gives any illegal clues, hit the buzzer!
-      </InstructionsText>
-    </TabooCard>
-  )
+	return (
+		<TabooCard tabooWord="Get Ready!">
+			<InstructionsText>
+				It’s the other team’s turn to give clues! You are the watcher for this round! If{' '}
+				{<KeyWord>{giver.name}</KeyWord>} says any words from the taboo list or gives any illegal clues, hit the
+				buzzer!
+			</InstructionsText>
+		</TabooCard>
+	)
 }
 
 const displayGiverTeamInstructions = (giver, watcher) => {
-  return (
-    <TabooCard tabooWord="Get Ready!">
-      <InstructionsText>
-        It's your turn to guess! {<KeyWord>{giver.name}</KeyWord>} will be
-        giving the clues, and {<KeyWord>{watcher.name}</KeyWord>} will be
-        checking for any illegal clues. Good luck!
-      </InstructionsText>
-    </TabooCard>
-  )
+	return (
+		<TabooCard tabooWord="Get Ready!">
+			<InstructionsText>
+				It's your turn to guess! {<KeyWord>{giver.name}</KeyWord>} will be giving the clues, and{' '}
+				{<KeyWord>{watcher.name}</KeyWord>} will be checking for any illegal clues. Good luck!
+			</InstructionsText>
+		</TabooCard>
+	)
 }
 
 const displayWatcherTeamInstructions = (giver, watcher) => {
-  return (
-    <TabooCard tabooWord="Just Relax!">
-      <InstructionsText>
-        It's the other team's turn to guess! {<KeyWord>{giver.name}</KeyWord>}{" "}
-        will be giving the clues, and {<KeyWord>{watcher.name}</KeyWord>} will be checking for any illegal clues.
-      </InstructionsText>
-    </TabooCard>
-  )
+	return (
+		<TabooCard tabooWord="Just Relax!">
+			<InstructionsText>
+				It's the other team's turn to guess! {<KeyWord>{giver.name}</KeyWord>} will be giving the clues, and{' '}
+				{<KeyWord>{watcher.name}</KeyWord>} will be checking for any illegal clues.
+			</InstructionsText>
+		</TabooCard>
+	)
 }
 export default RoundInstructionsCard

--- a/src/components/RoundInstructionsCard/__tests__/RoundInstructionsCard.test.js
+++ b/src/components/RoundInstructionsCard/__tests__/RoundInstructionsCard.test.js
@@ -6,9 +6,9 @@ import RoundInstructionsCard from "../RoundInstructionsCard"
 
 test("RoundInstructionsCard renders correctly", ()=> {
 	const props = {
-		role: 'watcherTeam',
-		giver: { name: 'Danielle', playerId: 123 },
-		watcher: { name: 'Stephen', playerId: 345 },
+		role: 'watcherTeam', 
+        giver: { name: 'Sam', playerId: '12345', team: 'team 1' },
+		watcher: { name: 'Jo', playerId: '23456', team: 'team 2' },
 		startRound: jest.fn(),
 	}
 

--- a/src/components/RoundInstructionsCard/__tests__/__snapshots__/RoundInstructionsCard.test.js.snap
+++ b/src/components/RoundInstructionsCard/__tests__/__snapshots__/RoundInstructionsCard.test.js.snap
@@ -19,14 +19,14 @@ exports[`RoundInstructionsCard renders correctly 1`] = `
       <span
         className="sc-fzplWN kxXpQP"
       >
-        Danielle
+        Sam
       </span>
+       will be giving the clues, and
        
-      will be giving the clues, and 
       <span
         className="sc-fzplWN kxXpQP"
       >
-        Stephen
+        Jo
       </span>
        will be checking for any illegal clues.
     </p>

--- a/src/pages/PlayGame/PlayGame.js
+++ b/src/pages/PlayGame/PlayGame.js
@@ -75,6 +75,8 @@ class PlayGame extends React.Component {
 		this.props.fetchDeck(gamecode)
 	}
 
+
+
 	render() {
 		const { gamecode } = this.props.match.params
 		const {game} = this.props

--- a/src/pages/PlayGame/PlayGame.js
+++ b/src/pages/PlayGame/PlayGame.js
@@ -70,7 +70,7 @@ class PlayGame extends React.Component {
 			//Style and add button to go to Join route so user can join properly
 			return <p>Player didn't join properly</p>
 		} else {
-			return <Round players={game.players} gameplay={game.gameplay} playerId={this.props.auth.uid}/>
+			return <Round gamecode={this.props.match.params.gamecode} players={game.players} gameplay={game.gameplay} playerId={this.props.auth.uid}/>
 		}
 	}
 }

--- a/src/pages/PlayGame/PlayGame.js
+++ b/src/pages/PlayGame/PlayGame.js
@@ -31,8 +31,6 @@ class PlayGame extends React.Component {
 	//toggle loading/verified so UI can render
 	verifyGameInfo = () => {
 		console.log('verifying game and player info')
-		const { gamecode } = this.props.match.params
-
 		const game = this.props.game
 		//Checks if falsy. Add additional edge cases in case empty object is returned
 		if (!game || game.status !== 'in progress') {
@@ -80,9 +78,9 @@ class PlayGame extends React.Component {
 	render() {
 		const { gamecode } = this.props.match.params
 		const {game} = this.props
-		console.log(game.gameplay?.deck?.length)
+		console.log(game.gameplay?.deck)
 
-		if (this.state.loading || !game.gameplay?.deck?.length) {
+		if (this.state.loading || !game.gameplay?.deck) {
 			//Update with actual loading component
 			return <p>Loading Firestore/Firebase</p>
 		} else if (game.status === 'new') {

--- a/src/pages/PlayGame/PlayGame.js
+++ b/src/pages/PlayGame/PlayGame.js
@@ -1,70 +1,95 @@
 import React from 'react'
-import RoundInfo from 'components/RoundInfo'
-import GameInfo from 'components/GameInfo'
-import PreRound from 'components/PreRound'
-import InRound from 'components/InRound'
-import PostRound from 'components/PostRound'
+import { Redirect } from 'react-router-dom'
+import { connect } from 'react-redux'
+import { firestoreConnect } from 'react-redux-firebase'
+import { compose } from 'redux'
+import Round from 'components/Round'
 
 class PlayGame extends React.Component {
 	constructor(props) {
 		super(props)
 
 		this.state = {
-			roundStatus: 'postRound', //preRound, InProgress, postRound
+			loading: true,
+			gameVerified: false,
+			playerVerified: false,
 		}
 	}
 
-	startRound = () => {
-		console.log('start round')
+	//Used to verify when props received from firebase and firestore are available
+	componentDidUpdate(prevProps) {
+		//While game is loading, check if game data from firestore and auth data from firebase have been received
+		//before verifying  gamecode and player
+		if (this.state.loading && this.props.gameDataReceived && this.props.auth.isLoaded) {
+			this.verifyGameInfo()
+		}
 	}
 
-	render() {
-		const dummyRoundData = {
-			role: 'giver',
-			giver: { name: 'Danielle', playerId: 123 },
-			watcher: { name: 'Stephen', playerId: 345 },
-			startRound: this.startRound,
+	//verify that game exists
+	//verify that current user is a player in game
+	//toggle loading/verified so UI can render
+	verifyGameInfo = () => {
+		console.log('verifying game and player info')
+		const { gamecode } = this.props.match.params
+
+		const game = this.props.game[gamecode]
+		//Checks if falsy. Add additional edge cases in case empty object is returned
+		if (!game || game.status !== 'in progress') {
+			console.log(game)
+			this.setState({
+				loading: false, //gameVerified false by default
+			})
+		} else {
+			//game info is valid, need to verify current user is a player in the game
+			const playerId = this.props.auth.uid
+			const players = game.players
+			//Verify current user has valid uid and is in players array in firestore
+			let playerVerified
+			const includedUserArr = players.filter((player) => player.playerId === playerId)
+			playerVerified = playerId && includedUserArr.length > 0 ? true : false
+			this.setState({
+				loading: false,
+				gameVerified: true,
+				playerVerified,
+			})
 		}
+	}
 
-		const dummyPostRoundData = [
-			{
-				word: 'Simba',
-				taboo: ['something', 'something', 'something', 'something', 'something'],
-				status: 'correct',
-			},
-			{
-				word: 'Mufasa',
-				taboo: ['something', 'something', 'something', 'something', 'something'],
-				status: 'correct',
-			},
-			{
-				word: 'Scar',
-				taboo: ['something', 'something', 'something', 'something', 'something'],
-				status: 'correct',
-			},
-			{
-				word: 'Voldemort',
-				taboo: ['something', 'something', 'something', 'something', 'something'],
-				status: 'skip',
-			},
-			{
-				word: 'American Revolution',
-				taboo: ['something', 'something', 'something', 'something', 'something'],
-				status: 'discard',
-			},
-		]
+	
 
-		return (
-			<React.Fragment>
-				<GameInfo />
-				<RoundInfo round={1} watcher="Stephen" giver="Danielle" />
-				{this.state.roundStatus === 'preRound' && <PreRound {...dummyRoundData} />}
-				{this.state.roundStatus === 'inProgress' && <InRound {...dummyRoundData} />}
-				{this.state.roundStatus === 'postRound' && <PostRound cardsPlayed={dummyPostRoundData} />}
-				{/* Links for Rules and Teams*/}
-			</React.Fragment>
-		)
+	render() {	
+		const { gamecode } = this.props.match.params
+		const game = this.props?.game?.[gamecode]
+
+		if (this.state.loading) {
+			//Update with actual loading component
+			return <p>Loading Firestore/Firebase</p>
+		} else if (game.status === 'new') {			
+			return <Redirect to={`/waiting/${gamecode}`} />
+		} else if (!this.state.playerVerified) {
+			//Style and add button to go to Join route so user can join properly
+			return <p>Player didn't join properly</p>
+		} else {
+			return <Round players={game.players} gameplay={game.gameplay} playerId={this.props.auth.uid}/>
+		}
 	}
 }
 
-export default PlayGame
+const mapStateToProps = (state, prevProps) => {
+	const { games } = state.firestore.data
+	return {
+		gamecode: state.game.gamecode, //tbd if adding this
+		game: games, //from firestore
+		gameDataReceived: state.firestore.status.requested[`games/${prevProps.match.params.gamecode}`],
+		auth: state.firebase.auth,
+	}
+}
+
+const mapDispatchToProps = (dispatch) => {
+	return {}
+}
+
+export default compose(
+	connect(mapStateToProps, mapDispatchToProps),
+	firestoreConnect((props) => [{ collection: 'games', doc: props.match.params.gamecode }])
+)(PlayGame)

--- a/src/pages/Waiting/Waiting.js
+++ b/src/pages/Waiting/Waiting.js
@@ -24,11 +24,6 @@ export class Waiting extends React.Component {
 		//While game is loading, check if game data from firestore and auth data from firebase have been received
 		//before verifying  gamecode and player
 		if (this.state.loading && this.props.gameDataReceived && this.props.auth.isLoaded) {
-			// const { gamecode } = this.props.match.params
-			// const game = this.props.game?.[gamecode] //object with game data
-			// const playerId = this.props.auth?.uid
-			// console.log(game)
-			// console.log(playerId)
 			this.verifyGameInfo()
 		}
 	}

--- a/src/store/actions/gameActions.js
+++ b/src/store/actions/gameActions.js
@@ -7,7 +7,7 @@ import {
 	 dbRequestGameDeck,
 	 dbSaveGameDeck
  } from 'utils/API'
- import { shuffleArray } from "utils/helpers"
+ import { shuffleArray, convertArrayToObject } from "utils/helpers"
 import { errorActionCreator } from './errorActions'
 
 const requestCreateGame = () => {
@@ -139,7 +139,9 @@ export const fetchGameDeck = (gamecode) => {
 		dbRequestGameDeck().then(response => {
 			console.log(response)
 			const shuffledDeck = shuffleArray(response)
-			dbSaveGameDeck(gamecode, shuffledDeck).then(res => {
+			//convert from array of objects to object with keys = objects.
+			const deckObject = convertArrayToObject(shuffledDeck)
+			dbSaveGameDeck(gamecode, deckObject).then(res => {
 				console.log("back from saving shuffled array")
 			})
 			dispatch(fetchGameDeckSuccess())

--- a/src/store/actions/gameActions.js
+++ b/src/store/actions/gameActions.js
@@ -1,4 +1,3 @@
-import { addPlayerSuccess } from 'store/actions/playerActions'
 import { createGame, createPlayer, addPlayer, verifyGameExists, dbUpdateGameStatus } from 'utils/API'
 import { errorActionCreator } from './errorActions'
 

--- a/src/store/actions/gameActions.js
+++ b/src/store/actions/gameActions.js
@@ -1,4 +1,13 @@
-import { createGame, createPlayer, addPlayer, verifyGameExists, dbUpdateGameStatus } from 'utils/API'
+import {
+	 createGame,
+	 createPlayer, 
+	 addPlayer, 
+	 verifyGameExists, 
+	 dbUpdateGameStatus,
+	 dbRequestGameDeck,
+	 dbSaveGameDeck
+ } from 'utils/API'
+ import { shuffleArray } from "utils/helpers"
 import { errorActionCreator } from './errorActions'
 
 const requestCreateGame = () => {
@@ -42,6 +51,20 @@ const requestUpdateGameStatus = () => {
 const updateGameStatusSuccess = () => {
 	return {
 		type: 'UPDATE_GAME_STATUS_SUCCESS',
+	}
+}
+
+const requestFetchGameDeck = () => {
+	return {
+		type: "REQUEST_FETCH_GAME_DECK",
+		pending: true
+	}
+}
+
+const fetchGameDeckSuccess = () => {
+	return {
+		type: "FETCH_GAME_DECK_SUCCESS",
+		pending: false
 	}
 }
 
@@ -105,5 +128,26 @@ export const updateGameStatus = (gamecode, status) => {
 				dispatch(errorActionCreator('UPDATE_GAME_FAILURE', error))
 			})
 		// })
+	}
+}
+
+export const fetchGameDeck = (gamecode) => {
+	
+	return (dispatch) => {
+		dispatch(requestFetchGameDeck())
+
+		dbRequestGameDeck().then(response => {
+			console.log(response)
+			const shuffledDeck = shuffleArray(response)
+			dbSaveGameDeck(gamecode, shuffledDeck).then(res => {
+				console.log("back from saving shuffled array")
+			})
+			dispatch(fetchGameDeckSuccess())
+
+		}).catch(error => {
+			console.log('there was an error retreiving the deck')
+			console.log(error)
+			dispatch(errorActionCreator('FETCH_GAME_DECK_FAILURE', error))
+		})
 	}
 }

--- a/src/store/actions/gameActions.js
+++ b/src/store/actions/gameActions.js
@@ -54,7 +54,7 @@ export const createNewGame = (gamecode, gameData, hostPlayerName) => {
 			createGame(gamecode, gameData)
 				.then(() => {
 					createPlayer(hostPlayerName).then((player) => {
-						const host = { ...player, team: null, host: true }
+						const host = { ...player, team: null, online:true, host: true }
 						//associates anonymous user with game instance in firestore
 						addPlayer(host, gamecode).then((player) => {
 							dispatch(createGameSuccess(gamecode))

--- a/src/store/actions/roundActions.js
+++ b/src/store/actions/roundActions.js
@@ -28,3 +28,12 @@ export const updateRoundStatus = (gamecode, status) => {
         //Update as success or failure
     }
 }
+
+export const changeCardStatus = (gamecode, status, round, currentIndex ) => {
+    return (dispatch) => {
+        console.log(gamecode)
+        console.log(status)
+        console.log(currentIndex)
+        console.log(round)
+    }
+}

--- a/src/store/actions/roundActions.js
+++ b/src/store/actions/roundActions.js
@@ -1,39 +1,60 @@
-import {dbUpdateRoundStatus } from "utils/API"
+import { dbUpdateRoundStatus, dbUpdateCardStatus } from 'utils/API'
 import { errorActionCreator } from './errorActions'
 
 const requestRoundStatus = () => {
-    return {
-        type: "REQUEST_ROUND_STATUS_UPDATE",
-    }
+	return {
+		type: 'REQUEST_ROUND_STATUS_UPDATE',
+	}
 }
 
 const roundStatusSuccess = (status) => {
-    return {
-        type: "ROUND_STATUS_UPDATE_SUCCESS",
-        payload: status
-    }
+	return {
+		type: 'ROUND_STATUS_UPDATE_SUCCESS',
+		payload: status,
+	}
+}
+
+const requestUpdateCardStatus = () => {
+	return {
+		type: 'REQUEST_UPDATE_CARD_STATUS',
+	}
+}
+
+const updateCardStatusSuccess = () => {
+	return {
+		type: 'UPDATE_CARD_STATUS_SUCCESS',
+	}
 }
 
 export const updateRoundStatus = (gamecode, status) => {
-    return (dispatch) => {
-        dispatch(requestRoundStatus())
-        console.log(gamecode)
-        console.log(status)
-        dbUpdateRoundStatus(gamecode, status).then(res => {
-            dispatch(roundStatusSuccess(status))
-        }).catch(error => {
-            dispatch(errorActionCreator('ROUND_STATUS_UPDATE_FAILURE', error))
-        })
-        //Update status in firebase
-        //Update as success or failure
-    }
+	return (dispatch) => {
+		dispatch(requestRoundStatus())
+		console.log(gamecode)
+		console.log(status)
+		dbUpdateRoundStatus(gamecode, status)
+			.then((res) => {
+				dispatch(roundStatusSuccess(status))
+			})
+			.catch((error) => {
+				dispatch(errorActionCreator('ROUND_STATUS_UPDATE_FAILURE', error))
+			})
+		//Update status in firebase
+		//Update as success or failure
+	}
 }
 
-export const changeCardStatus = (gamecode, status, round, currentIndex ) => {
-    return (dispatch) => {
-        console.log(gamecode)
-        console.log(status)
-        console.log(currentIndex)
-        console.log(round)
-    }
+export const changeCardStatus = (gamecode, status, round, currentIndex) => {
+	return (dispatch) => {
+		//dispatch changing card in progress
+		//set the status of the current card in firebase, and update the index
+		//dispatch changing card complete
+		dispatch(requestUpdateCardStatus())
+		dbUpdateCardStatus(gamecode, status, currentIndex)
+			.then(() => {
+				dispatch(updateCardStatusSuccess())
+			})
+			.catch((error) => {
+				dispatch(errorActionCreator('ROUND_STATUS_UPDATE_FAILURE', error))
+			})
+	}
 }

--- a/src/store/actions/roundActions.js
+++ b/src/store/actions/roundActions.js
@@ -1,0 +1,30 @@
+import {dbUpdateRoundStatus } from "utils/API"
+import { errorActionCreator } from './errorActions'
+
+const requestRoundStatus = () => {
+    return {
+        type: "REQUEST_ROUND_STATUS_UPDATE",
+    }
+}
+
+const roundStatusSuccess = (status) => {
+    return {
+        type: "ROUND_STATUS_UPDATE_SUCCESS",
+        payload: status
+    }
+}
+
+export const updateRoundStatus = (gamecode, status) => {
+    return (dispatch) => {
+        dispatch(requestRoundStatus())
+        console.log(gamecode)
+        console.log(status)
+        dbUpdateRoundStatus(gamecode, status).then(res => {
+            dispatch(roundStatusSuccess(status))
+        }).catch(error => {
+            dispatch(errorActionCreator('ROUND_STATUS_UPDATE_FAILURE', error))
+        })
+        //Update status in firebase
+        //Update as success or failure
+    }
+}

--- a/src/store/reducers/gameReducer.js
+++ b/src/store/reducers/gameReducer.js
@@ -2,8 +2,8 @@ import { errorReducer } from './errorReducer'
 
 const initState = {
 	pending: false,
-	gamecode: "",
-	error: null
+	gamecode: '',
+	error: null,
 }
 
 export const gameReducer = (state = initState, action) => {
@@ -40,6 +40,15 @@ export const gameReducer = (state = initState, action) => {
 			return state
 		case 'REMOVE_GAME':
 			console.log('removing game status')
+			return state
+		case 'REQUEST_FETCH_GAME_DECK':
+			console.log('requesting game deck')
+			return state
+		case 'FETCH_GAME_DECK_SUCCESS':
+			console.log('request game deck success')
+			return state
+		case 'FETCH_GAME_DECK_FAILURE':
+			console.log('request game deck failure')
 			return state
 		case 'CLEAR_GAME_ERRORS':
 			return {

--- a/src/store/reducers/rootReducer.js
+++ b/src/store/reducers/rootReducer.js
@@ -1,14 +1,14 @@
 import { combineReducers } from 'redux'
 import { gameReducer } from './gameReducer'
 import { playersReducer } from './playersReducer'
-// import { errorReducer } from './errorReducer'
+import { roundReducer } from './roundReducer'
 import { firestoreReducer } from 'redux-firestore'
 import { firebaseReducer } from 'react-redux-firebase'
 
 const rootReducer = combineReducers({
 	game: gameReducer,
 	players: playersReducer,
-	// error: errorReducer,
+	round: roundReducer,
 	firestore: firestoreReducer,
 	firebase: firebaseReducer, //syncs FB auth data with the redux state. Can detect authentication
 })

--- a/src/store/reducers/roundReducer.js
+++ b/src/store/reducers/roundReducer.js
@@ -3,7 +3,7 @@ import { errorReducer } from './errorReducer'
 const initState = {
 	pending: false,
 	error: null,
-	status: 'new',
+	status: 'preround',
 }
 
 export const roundReducer = (state = initState, action) => {

--- a/src/store/reducers/roundReducer.js
+++ b/src/store/reducers/roundReducer.js
@@ -1,0 +1,30 @@
+import { errorReducer } from './errorReducer'
+
+const initState = {
+	pending: false,
+	error: null,
+	status: 'new',
+}
+
+export const roundReducer = (state = initState, action) => {
+	switch (action.type) {
+		case 'REQUEST_ROUND_STATUS_UPDATE':
+			return {
+				...errorReducer(state, action),
+				pending: true,
+			}
+		case 'ROUND_STATUS_UPDATE_SUCCESS':
+			return {
+				...errorReducer(state, action),
+				status: action.payload.status,
+				pending: false,
+			}
+		case 'ROUND_STATUS_UPDATE_FAILURE':
+			return {
+				...errorReducer(state, action),
+				pending: false,
+			}
+		default:
+			return state
+	}
+}

--- a/src/store/reducers/roundReducer.js
+++ b/src/store/reducers/roundReducer.js
@@ -24,6 +24,25 @@ export const roundReducer = (state = initState, action) => {
 				...errorReducer(state, action),
 				pending: false,
 			}
+		case 'REQUEST_UPDATE_CARD_STATUS':
+			console.log('REQUEST_UPDATE_CARD_STATUS')
+
+			return {
+				...errorReducer(state, action),
+				pending: true,
+			}
+		case 'UPDATE_CARD_STATUS_SUCCESS':
+			console.log('UPDATE_CARD_STATUS_SUCCESS')
+			return {
+				...errorReducer(state, action),
+				pending: false,
+			}
+		case 'UPDATE_CARD_STATUS_FAILURE':
+			console.log('UPDATE_CARD_STATUS_FAILURE')
+			return {
+				...errorReducer(state, action),
+				pending: false,
+			}
 		default:
 			return state
 	}

--- a/src/utils/API.js
+++ b/src/utils/API.js
@@ -77,6 +77,7 @@ export const createPlayer = (playerName) => {
 
 export const addPlayer = (player, gamecode) => {
 	console.log('action player in firestore to ', gamecode)
+
 	console.log(player)
 	return firebase
 		.firestore()

--- a/src/utils/API.js
+++ b/src/utils/API.js
@@ -140,21 +140,21 @@ export const dbUpdateGameStatus = (gamecode, status) => {
 	console.log(status)
 	console.log(gamecode)
 	// return new Promise((resolve, reject) => {
-		return firebase
-			.firestore()
-			.collection('games')
-			.doc(gamecode)
-			.update({
-				status: status,
-			})
-			.then(() => {
-				console.log('game updated to ', status)
-				return
-			})
-			.catch((error) => {
-				console.log('error updating game')
-				return error
-			})
+	return firebase
+		.firestore()
+		.collection('games')
+		.doc(gamecode)
+		.update({
+			status: status,
+		})
+		.then(() => {
+			console.log('game updated to ', status)
+			return
+		})
+		.catch((error) => {
+			console.log('error updating game')
+			return error
+		})
 	// })
 }
 
@@ -163,21 +163,61 @@ export const dbUpdateRoundStatus = (gamecode, status) => {
 	console.log(status)
 	console.log(gamecode)
 	// return new Promise((resolve, reject) => {
-		return firebase
-			.firestore()
-			.collection('games')
-			.doc(gamecode)
-			.update({
-				"gameplay.status": status,
-			})
-			.then(() => {
-				console.log('game updated to ', status)
-				return
-			})
-			.catch((error) => {
-				console.log('error updating game')
-				return error
-			})
+	return firebase
+		.firestore()
+		.collection('games')
+		.doc(gamecode)
+		.update({
+			'gameplay.status': status,
+		})
+		.then(() => {
+			console.log('game updated to ', status)
+			return
+		})
+		.catch((error) => {
+			console.log('error updating game')
+			return error
+		})
 	// })
 }
 
+export const dbRequestGameDeck = () => {
+	const gamedeck = []
+	return firebase
+		.firestore()
+		.collection('cards')
+		.get()
+		.then((response) => {
+			response.forEach((document) => {
+				let card = {
+
+				}
+				console.log(document.id)
+				console.log(document.data())
+				card.word = document.id
+				card.tabooList = document.data().tabooList
+				gamedeck.push(card)
+			})
+			return gamedeck
+		})
+		.catch((error) => {
+			console.log(error)
+			return error
+		})
+}
+
+export const dbSaveGameDeck = (gamecode, deck) => {
+	console.log(deck)
+	
+	return firebase.firestore().collection('games').doc(gamecode).update({
+		'gameplay.deck': deck,
+		'gameplay.cardIndex': 0
+	}).then(res => {
+		console.log(res)
+		console.log("saved shuffled array")
+		return
+	}).catch(error => {
+		console.log(error)
+		return error
+	})
+}

--- a/src/utils/API.js
+++ b/src/utils/API.js
@@ -163,12 +163,16 @@ export const dbUpdateRoundStatus = (gamecode, status) => {
 	console.log(status)
 	console.log(gamecode)
 	// return new Promise((resolve, reject) => {
+	let date = new Date() 
+	let endTime = date.setSeconds(date.getSeconds() + 61)
+	console.log(endTime)
 	return firebase
 		.firestore()
 		.collection('games')
 		.doc(gamecode)
 		.update({
 			'gameplay.status': status,
+			"gameplay.roundEndTime": endTime
 		})
 		.then(() => {
 			console.log('game updated to ', status)

--- a/src/utils/API.js
+++ b/src/utils/API.js
@@ -110,7 +110,7 @@ export const dbUpdateTeam = (gamecode, playerId, team) => {
 						reject('Document does not exist')
 					}
 					const players = game.data().players
-					//find player object and update team property
+					//find player object based on playerId and update team property
 					console.log(players)
 					const updatedPlayers = players.map((player) => {
 						if (player.playerId !== playerId) return player
@@ -163,7 +163,7 @@ export const dbUpdateRoundStatus = (gamecode, status) => {
 	console.log(status)
 	console.log(gamecode)
 	// return new Promise((resolve, reject) => {
-	let date = new Date() 
+	let date = new Date()
 	let endTime = date.setSeconds(date.getSeconds() + 61)
 	console.log(endTime)
 	return firebase
@@ -172,7 +172,7 @@ export const dbUpdateRoundStatus = (gamecode, status) => {
 		.doc(gamecode)
 		.update({
 			'gameplay.status': status,
-			"gameplay.roundEndTime": endTime
+			'gameplay.roundEndTime': endTime,
 		})
 		.then(() => {
 			console.log('game updated to ', status)
@@ -193,9 +193,7 @@ export const dbRequestGameDeck = () => {
 		.get()
 		.then((response) => {
 			response.forEach((document) => {
-				let card = {
-
-				}
+				let card = {}
 				console.log(document.id)
 				console.log(document.data())
 				card.word = document.id
@@ -212,16 +210,68 @@ export const dbRequestGameDeck = () => {
 
 export const dbSaveGameDeck = (gamecode, deck) => {
 	console.log(deck)
-	
-	return firebase.firestore().collection('games').doc(gamecode).update({
-		'gameplay.deck': deck,
-		'gameplay.cardIndex': 0
-	}).then(res => {
-		console.log(res)
-		console.log("saved shuffled array")
-		return
-	}).catch(error => {
-		console.log(error)
-		return error
+
+	return firebase
+		.firestore()
+		.collection('games')
+		.doc(gamecode)
+		.update({
+			'gameplay.deck': deck,
+			'gameplay.cardIndex': 0,
+		})
+		.then((res) => {
+			console.log(res)
+			console.log('saved shuffled array')
+			return
+		})
+		.catch((error) => {
+			console.log(error)
+			return error
+		})
+}
+
+export const dbUpdateCardStatus = (gamecode, status, currentIndex) => {
+	console.log('updating card status in fb...')
+	const gamePath = firebase.firestore().collection('games').doc(gamecode)
+	return firebase.firestore().runTransaction((transaction) => {
+		return transaction
+			.get(gamePath)
+			.then((game) => {
+				if (!game.exists) {
+					console.log('game does not exist')
+					throw new Error("game doesn't exist...")
+				}
+
+				const { cardIndex, deck, round, half } = game.data().gameplay
+
+				//If the index provided no longer matches, giver and watcher may have selected a button at nearly the same time. This allows only one update to occur and discard
+				if (cardIndex !== currentIndex) {
+					console.log("card index was already changed. Don't proceed")
+					throw new Error("card index was already changed. Don't proceed")
+				}
+
+			
+				const updatedCard = {
+					...deck[cardIndex],
+					status: status,
+					//Will be used to filter cards that were played in the current round
+					roundPlayed: `${round}-${half}`,
+				}
+
+				console.log(updatedCard)
+				const cardPath = `gameplay.deck.${currentIndex}`
+				console.log(cardPath)
+				transaction.update(gamePath, {
+					'gameplay.cardIndex': currentIndex + 1,
+					[cardPath]: updatedCard,
+				})
+			})
+			.then(() => {
+				console.log('transaction successful')
+				return
+			})
+			.catch((error) => {
+				console.log(error)
+			})
 	})
 }

--- a/src/utils/API.js
+++ b/src/utils/API.js
@@ -41,6 +41,7 @@ export const verifyGameExists = (gamecode) => {
 		})
 }
 
+//Creates an anonymous user in firebase with a uid generated.
 export const createPlayer = (playerName) => {
 	console.log('creating player in firebase...')
 	return firebase
@@ -138,7 +139,7 @@ export const dbUpdateGameStatus = (gamecode, status) => {
 	console.log('updating game status')
 	console.log(status)
 	console.log(gamecode)
-	return new Promise((resolve, reject) => {
+	// return new Promise((resolve, reject) => {
 		return firebase
 			.firestore()
 			.collection('games')
@@ -148,11 +149,35 @@ export const dbUpdateGameStatus = (gamecode, status) => {
 			})
 			.then(() => {
 				console.log('game updated to ', status)
-				resolve()
+				return
 			})
 			.catch((error) => {
 				console.log('error updating game')
-				reject(error)
+				return error
 			})
-	})
+	// })
 }
+
+export const dbUpdateRoundStatus = (gamecode, status) => {
+	console.log('updating game status')
+	console.log(status)
+	console.log(gamecode)
+	// return new Promise((resolve, reject) => {
+		return firebase
+			.firestore()
+			.collection('games')
+			.doc(gamecode)
+			.update({
+				"gameplay.status": status,
+			})
+			.then(() => {
+				console.log('game updated to ', status)
+				return
+			})
+			.catch((error) => {
+				console.log('error updating game')
+				return error
+			})
+	// })
+}
+

--- a/src/utils/API.js
+++ b/src/utils/API.js
@@ -194,9 +194,7 @@ export const dbRequestGameDeck = () => {
 		.then((response) => {
 			response.forEach((document) => {
 				let card = {}
-				console.log(document.id)
-				console.log(document.data())
-				card.word = document.id
+							card.word = document.id
 				card.tabooList = document.data().tabooList
 				gamedeck.push(card)
 			})

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -1,107 +1,12 @@
-import { v4 as uuidv4 } from "uuid"
 
-export function createNewCode() {
-  return new Promise(function (resolve, reject) {
-    const longCode = uuidv4()
-    //shorten to only use first part of code
-    const shortCode = longCode.split("-")[0]
-    resolve(shortCode)
-  })
-}
-
-//Converts FB object with a property for each element Object
-// into array of element objects
-export function convertFBObjectToArray(fbObject) {
-  const fbArray = []
-
-  /*
-  Sample Input
-    fbObject = {
-      12345: {
-        name: "Bob",
-        id: 12345
-      },
-      98765: {
-        name: "Test",
-        id: 98765
-      }
-    Sample Output: [{name: "Bob", id: 12345}, {name:"Test", id:98765}]
-}]
-  }*/
-
-  for (let keyObj in fbObject) {
-    const newObj = {}
-    for (let key in fbObject[keyObj]) {
-      newObj[key] = fbObject[keyObj][key]
-    }
-    // console.log(newObj)
-    fbArray.push(newObj)
-  }
-  return fbArray
-}
-
-//Checks if array contains an object with the property name === value
-export function includedInArrayOfObjects(arr, property, value) {
-  const filteredArray = arr.filter((item) => item[property] === value)
-  // console.log(filteredArray)
-  return filteredArray.length > 0
-}
-
-
-//Called when NewGame and PlayGame components mount by looping over each type of listener required.
-//Creates the path of the specified listener, and calls function to attach listener, passing in callback to be called
-//when each listener fires (database changes at specified path)
-export function setupListenerRequest
-  (listeners, index, gamecode, createListener, listenerHandler) {
-    let listenerPath = ""
-    switch (listeners[index]) {
-      case "gameStatus":
-        console.log("set gameStatus listener")
-        listenerPath = `games/${gamecode}/status`
-        break
-      case "players":
-        console.log("set players listener")
-        listenerPath = `games/${gamecode}/players`
-        break
-      case "roundStatus":
-        console.log("set roundStatus")
-        listenerPath = `games/${gamecode}/round/status`
-        break
-      case "roundNumber":
-        console.log("set roundNumberStatus")
-        listenerPath = `games/${gamecode}/round/number`
-        break
-      case "currentCardIndex":
-        console.log("set cardIndex")
-        listenerPath = `games/${gamecode}/deck/cardInfo`
-        break
-      case "currentCards":
-        console.log("set currentCards")
-        listenerPath = `games/${gamecode}/deck/cards`    
-        break
-      case "score":
-        console.log("set scores")
-        listenerPath = `games/${gamecode}/score`
-        break
-      default:
-        //pickle - update once error logging set
-        console.log("something broke :/")
-        throw new Error("something broke in listener")        
-    }
-    createListener(listenerPath, listenerHandler, listeners[index])
+  /* Randomize array in-place using Durstenfeld shuffle algorithm */
+export const shuffleArray = (array) => {
+  for (var i = array.length - 1; i > 0; i--) {
+      var j = Math.floor(Math.random() * (i + 1));
+      var temp = array[i];
+      array[i] = array[j];
+      array[j] = temp;
   }
 
-  export function shuffleArray(arr) {
-    console.log("starting array: ", arr)
-    for (let i = arr.length -1; i > 0; i--) {
-      const j = Math.floor((Math.random() * (i + 1)))
-      // console.log(j)
-      const temp = arr[i]
-      // console.log(temp)
-      arr[i] = arr[j]
-      arr[j] = temp
-    }
-    console.log("shuffled arr: ", arr)
-    return arr;
-    // return new Promise((res,rej) => res(arr))
-  }
+  return array
+}

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -10,3 +10,16 @@ export const shuffleArray = (array) => {
 
   return array
 }
+
+export const convertArrayToObject = (array) => {
+  console.log("converting array")
+  const convertedObject = array.reduce((updatedObject, element, index) => {
+
+    return {
+      ...updatedObject,
+      [index]: element
+    }
+  }, {})
+  console.log(convertedObject)
+  return convertedObject
+}


### PR DESCRIPTION
Completed the following functionality:

- Giver and Watcher player determined at beginning of round.
- Shuffled Deck generated at beginning of game
- Giver can trigger start of round for all players
- Giver and Watcher can see current taboo card
- Giver can click Skip or Next to update card status and view next taboo card in deck
- Watcher can select Buzzer to give card 'Discard' status and move to next card
- Status of cards are stored in firestore along with round card was played.
- Closes #77 